### PR TITLE
fix: update halls

### DIFF
--- a/Modules/AvoidableDamageData/HallsOfAtonement.lua
+++ b/Modules/AvoidableDamageData/HallsOfAtonement.lua
@@ -18,17 +18,6 @@ local mistakes = {
 		spell = 319703,
 	},
 	{
-		-- 粉碎猛擊 (哈奇厄斯)
-		type = AD.MISTAKE.SPELL_DAMAGE,
-		spell = 322936,
-		playerIsNotTank = true,
-	},
-	{
-		-- 拋擲殘骸 (哈奇厄斯)
-		type = AD.MISTAKE.SPELL_DAMAGE,
-		spell = 322945,
-	},
-	{
 		-- 念力碰撞
 		type = AD.MISTAKE.SPELL_DAMAGE,
 		spell = 323126,


### PR DESCRIPTION
## Description

这两个技能在11.2已经变为持续aoe技能，无法避免，会造成错误统计。
由于有一个技能写了T避免统计，然后又是全团AOE，会显得T完美规避所有伤害。
<img width="696" height="252" alt="微信图片_2025-08-25_004305_853" src="https://github.com/user-attachments/assets/24612405-c0ff-439d-bbb5-0be2b8f4dcaf" />
[ElitismHelper已经排除](https://github.com/amki/ElitismHelper/blob/956ffd76460e1c1508ab661209d4a8c42608a53f/ElitismHelper.lua#L751)

详情可见视频：https://www.bilibili.com/video/BV1kShEzSEer?t=665.9

另外，可考虑将该boss的玻璃碎片 323001 纳入进来（地板技能需远离）。
[ElitismHelper已经纳入](https://github.com/amki/ElitismHelper/blob/956ffd76460e1c1508ab661209d4a8c42608a53f/ElitismHelper.lua#L1441)


